### PR TITLE
add/ -s to serve in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,4 +22,4 @@ RUN npm install -g serve
 # Expose the port that your app is running on
 EXPOSE 3000
 
-CMD ["serve", "dist", "-l", "3000"]
+CMD ["serve", "dist", "-s", "-l", "3000"]


### PR DESCRIPTION
This should fix the "404 the requested path could not be found" error we get when refreshing the page.